### PR TITLE
Add __toString to a few methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ To make the example IPv4-only, replace `IPv6` with `IPv4`. To make the example v
     - `->getNetmask(): \phpseclib\Math\BigInteger`
 - `IPv4Range`
     - `::Make(string $range): \Dxw\Result\Result`
+    - `->__toString(): string`
     - `->getAddress(): \Dxw\CIDR\IPv4Address`
     - `->getBlock(): \Dxw\CIDR\IPv4Block`
     - `->containsAddress(\Dxw\CIDR\AddressBase $address): bool`
 - `IPv6Range`
     - `::Make(string $range): \Dxw\Result\Result`
+    - `->__toString(): string`
     - `->getAddress(): \Dxw\CIDR\IPv6Address`
     - `->getBlock(): \Dxw\CIDR\IPv6Block`
     - `->containsAddress(\Dxw\CIDR\AddressBase $address): bool`

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ To make the example IPv4-only, replace `IPv6` with `IPv4`. To make the example v
     - `::Make(string $range): \Dxw\Result\Result`
 - `IPv4Address`
     - `::Make(string $address): \Dxw\Result\Result`
+    - `::FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result`
     - `->__toString(): string`
     - `->getBinary(): \phpseclib\Math\BigInteger`
 - `IPv6Address`
     - `::Make(string $address): \Dxw\Result\Result`
+    - `::FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result`
     - `->__toString(): string`
     - `->getBinary(): \phpseclib\Math\BigInteger`
 - `IPv4Block`

--- a/README.md
+++ b/README.md
@@ -57,39 +57,39 @@ Example of testing if an IPv6 address falls within a particular IPv6 range:
 To make the example IPv4-only, replace `IPv6` with `IPv4`. To make the example version agnostic, replace `IPv6` with just `IP`.
 
 - `IP`
-    - `::contains(string $addressOrRange, string $address): \Dxw\Result\Result`
+    - `::contains(string $addressOrRange, string $address): \Dxw\Result\Result<bool>`
 - `IPAddress`
-    - `::Make(string $address): \Dxw\Result\Result`
+    - `::Make(string $address): \Dxw\Result\Result<AddressBase>` (`AddressBase` is the abstract superclass of `IPv4Address` and `IPv6Address`)
 - `IPRange`
-    - `::Make(string $range): \Dxw\Result\Result`
+    - `::Make(string $range): \Dxw\Result\Result<RangeBase>` (`RangeBase` is the abstract superclass of `IPv4Range` and `IPv6Range`)
 - `IPv4Address`
-    - `::Make(string $address): \Dxw\Result\Result`
-    - `::FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result`
+    - `::Make(string $address): \Dxw\Result\Result<IPv4Address>`
+    - `::FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result<IPv4Address>`
     - `->__toString(): string`
     - `->getBinary(): \phpseclib\Math\BigInteger`
 - `IPv6Address`
-    - `::Make(string $address): \Dxw\Result\Result`
-    - `::FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result`
+    - `::Make(string $address): \Dxw\Result\Result<IPv6Address>`
+    - `::FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result<IPv6Address>`
     - `->__toString(): string`
     - `->getBinary(): \phpseclib\Math\BigInteger`
 - `IPv4Block`
-    - `::Make(int $value): \Dxw\Result\Result`
+    - `::Make(int $value): \Dxw\Result\Result<IPv4Block>`
     - `->__toString(): string`
     - `->getValue(): int`
     - `->getNetmask(): \phpseclib\Math\BigInteger`
 - `IPv6Block`
-    - `::Make(int $value): \Dxw\Result\Result`
+    - `::Make(int $value): \Dxw\Result\Result<IPv6Block>`
     - `->__toString(): string`
     - `->getValue(): int`
     - `->getNetmask(): \phpseclib\Math\BigInteger`
 - `IPv4Range`
-    - `::Make(string $range): \Dxw\Result\Result`
+    - `::Make(string $range): \Dxw\Result\Result<IPv4Range>`
     - `->__toString(): string`
     - `->getAddress(): \Dxw\CIDR\IPv4Address`
     - `->getBlock(): \Dxw\CIDR\IPv4Block`
     - `->containsAddress(\Dxw\CIDR\AddressBase $address): bool`
 - `IPv6Range`
-    - `::Make(string $range): \Dxw\Result\Result`
+    - `::Make(string $range): \Dxw\Result\Result<IPv6Range>`
     - `->__toString(): string`
     - `->getAddress(): \Dxw\CIDR\IPv6Address`
     - `->getBlock(): \Dxw\CIDR\IPv6Block`

--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ To make the example IPv4-only, replace `IPv6` with `IPv4`. To make the example v
     - `->getBinary(): \phpseclib\Math\BigInteger`
 - `IPv4Block`
     - `::Make(int $value): \Dxw\Result\Result`
+    - `->__toString(): string`
     - `->getValue(): int`
     - `->getNetmask(): \phpseclib\Math\BigInteger`
 - `IPv6Block`
     - `::Make(int $value): \Dxw\Result\Result`
+    - `->__toString(): string`
     - `->getValue(): int`
     - `->getNetmask(): \phpseclib\Math\BigInteger`
 - `IPv4Range`

--- a/spec/ipv4address.spec.php
+++ b/spec/ipv4address.spec.php
@@ -39,6 +39,38 @@ describe(\Dxw\CIDR\IPv4Address::class, function () {
         });
     });
 
+    describe('::FromBinary()', function () {
+        it('handles correct addresses (small)', function () {
+            $result = \Dxw\CIDR\IPv4Address::FromBinary(new \phpseclib\Math\BigInteger(1));
+
+            expect($result->isErr())->to->equal(false);
+            expect($result->unwrap())->to->be->instanceof(\Dxw\CIDR\IPv4Address::class);
+            expect($result->unwrap()->__toString())->to->equal('0.0.0.1');
+        });
+
+        it('handles correct addresses (large)', function () {
+            $result = \Dxw\CIDR\IPv4Address::FromBinary(new \phpseclib\Math\BigInteger('ffffffff', 16));
+
+            expect($result->isErr())->to->equal(false);
+            expect($result->unwrap())->to->be->instanceof(\Dxw\CIDR\IPv4Address::class);
+            expect($result->unwrap()->__toString())->to->equal('255.255.255.255');
+        });
+
+        it('handles broken addresses (too large)', function () {
+            $result = \Dxw\CIDR\IPv4Address::FromBinary(new \phpseclib\Math\BigInteger('100000000', 16));
+
+            expect($result->isErr())->to->equal(true);
+            expect($result->getErr())->to->equal('address size cannot exceed 32 bytes');
+        });
+
+        it('handles broken addresses (negative)', function () {
+            $result = \Dxw\CIDR\IPv4Address::FromBinary(new \phpseclib\Math\BigInteger(-1));
+
+            expect($result->isErr())->to->equal(true);
+            expect($result->getErr())->to->equal('address cannot be negative');
+        });
+    });
+
     describe('->getBinary()', function () {
         it('returns a binary representation', function () {
             $address = \Dxw\CIDR\IPv4Address::Make('127.0.0.1')->unwrap();

--- a/spec/ipv4block.spec.php
+++ b/spec/ipv4block.spec.php
@@ -62,4 +62,15 @@ describe(\Dxw\CIDR\IPv4Block::class, function () {
             );
         });
     });
+
+    describe('->__toString()', function () {
+        it('returns strings', function () {
+            expect(\Dxw\CIDR\IPv4Block::Make(0)->unwrap()->__toString())->to->equal('/0');
+            expect(\Dxw\CIDR\IPv4Block::Make(1)->unwrap()->__toString())->to->equal('/1');
+            expect(\Dxw\CIDR\IPv4Block::Make(5)->unwrap()->__toString())->to->equal('/5');
+            expect(\Dxw\CIDR\IPv4Block::Make(17)->unwrap()->__toString())->to->equal('/17');
+            expect(\Dxw\CIDR\IPv4Block::Make(24)->unwrap()->__toString())->to->equal('/24');
+            expect(\Dxw\CIDR\IPv4Block::Make(32)->unwrap()->__toString())->to->equal('/32');
+        });
+    });
 });

--- a/spec/ipv4range.spec.php
+++ b/spec/ipv4range.spec.php
@@ -86,4 +86,11 @@ describe(\Dxw\CIDR\IPv4Range::class, function () {
             expect($range->containsAddress($address))->to->equal(false);
         });
     });
+
+    describe('->__toString()', function () {
+        it('returns strings', function () {
+            expect(\Dxw\CIDR\IPv4Range::Make('192.168.1.1/24')->unwrap()->__toString())->to->equal('192.168.1.0/24');
+            expect(\Dxw\CIDR\IPv4Range::Make('127.0.0.1/32')->unwrap()->__toString())->to->equal('127.0.0.1/32');
+        });
+    });
 });

--- a/spec/ipv6address.spec.php
+++ b/spec/ipv6address.spec.php
@@ -41,6 +41,38 @@ describe(\Dxw\CIDR\IPv6Address::class, function () {
         });
     });
 
+    describe('::FromBinary()', function () {
+        it('handles correct addresses (small)', function () {
+            $result = \Dxw\CIDR\IPv6Address::FromBinary(new \phpseclib\Math\BigInteger(1));
+
+            expect($result->isErr())->to->equal(false);
+            expect($result->unwrap())->to->be->instanceof(\Dxw\CIDR\IPv6Address::class);
+            expect($result->unwrap()->__toString())->to->equal('::1');
+        });
+
+        it('handles correct addresses (large)', function () {
+            $result = \Dxw\CIDR\IPv6Address::FromBinary(new \phpseclib\Math\BigInteger('ffffffffffffffffffffffffffffffff', 16));
+
+            expect($result->isErr())->to->equal(false);
+            expect($result->unwrap())->to->be->instanceof(\Dxw\CIDR\IPv6Address::class);
+            expect($result->unwrap()->__toString())->to->equal('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff');
+        });
+
+        it('handles broken addresses (too large)', function () {
+            $result = \Dxw\CIDR\IPv6Address::FromBinary(new \phpseclib\Math\BigInteger('100000000000000000000000000000000', 16));
+
+            expect($result->isErr())->to->equal(true);
+            expect($result->getErr())->to->equal('address size cannot exceed 128 bytes');
+        });
+
+        it('handles broken addresses (negative)', function () {
+            $result = \Dxw\CIDR\IPv6Address::FromBinary(new \phpseclib\Math\BigInteger(-1));
+
+            expect($result->isErr())->to->equal(true);
+            expect($result->getErr())->to->equal('address cannot be negative');
+        });
+    });
+
     describe('->getBinary()', function () {
         it('returns a binary representation', function () {
             $address = \Dxw\CIDR\IPv6Address::Make('::1')->unwrap();

--- a/spec/ipv6block.spec.php
+++ b/spec/ipv6block.spec.php
@@ -62,4 +62,17 @@ describe(\Dxw\CIDR\IPv6Block::class, function () {
             );
         });
     });
+
+    describe('->__toString()', function () {
+        it('returns strings', function () {
+            expect(\Dxw\CIDR\IPv6Block::Make(0)->unwrap()->__toString())->to->equal('/0');
+            expect(\Dxw\CIDR\IPv6Block::Make(1)->unwrap()->__toString())->to->equal('/1');
+            expect(\Dxw\CIDR\IPv6Block::Make(5)->unwrap()->__toString())->to->equal('/5');
+            expect(\Dxw\CIDR\IPv6Block::Make(17)->unwrap()->__toString())->to->equal('/17');
+            expect(\Dxw\CIDR\IPv6Block::Make(24)->unwrap()->__toString())->to->equal('/24');
+            expect(\Dxw\CIDR\IPv6Block::Make(32)->unwrap()->__toString())->to->equal('/32');
+            expect(\Dxw\CIDR\IPv6Block::Make(64)->unwrap()->__toString())->to->equal('/64');
+            expect(\Dxw\CIDR\IPv6Block::Make(128)->unwrap()->__toString())->to->equal('/128');
+        });
+    });
 });

--- a/spec/ipv6range.spec.php
+++ b/spec/ipv6range.spec.php
@@ -86,4 +86,11 @@ describe(\Dxw\CIDR\IPv6Range::class, function () {
             expect($range->containsAddress($address))->to->equal(false);
         });
     });
+
+    describe('->__toString()', function () {
+        it('returns strings', function () {
+            expect(\Dxw\CIDR\IPv6Range::Make('2001:db8::123/128')->unwrap()->__toString())->to->equal('2001:db8::123/128');
+            expect(\Dxw\CIDR\IPv6Range::Make('2001:db8::123/64')->unwrap()->__toString())->to->equal('2001:db8::/64');
+        });
+    });
 });

--- a/src/AddressBase.php
+++ b/src/AddressBase.php
@@ -7,6 +7,9 @@ abstract class AddressBase
     /** @var string */
     private $address;
 
+    /** @var int */
+    protected static $size;
+
     public static function Make(string $address): \Dxw\Result\Result
     {
         // I hate to suppress warnings, but there's no other way to disable
@@ -34,6 +37,25 @@ abstract class AddressBase
             throw new \ErrorException("inet_ntop error: return value was false");
         }
         return $value;
+    }
+
+    public static function FromBinary(\phpseclib\Math\BigInteger $binary): \Dxw\Result\Result
+    {
+        if ($binary->compare(new \phpseclib\Math\BigInteger(0)) < 0) {
+            return \Dxw\Result\Result::err(sprintf('address cannot be negative', static::$size));
+        }
+
+        $numBytes = intdiv(static::$size, 4);
+        $numNibbles = intdiv(static::$size, 8);
+
+        if (strlen($binary->toHex()) > $numBytes) {
+            return \Dxw\Result\Result::err(sprintf('address size cannot exceed %s bytes', static::$size));
+        }
+
+        $bytes = $binary->toBytes();
+        $bytes = str_pad($bytes, $numNibbles, "\x00", STR_PAD_LEFT);
+
+        return \Dxw\Result\Result::ok(new static($bytes));
     }
 
     public function getBinary(): \phpseclib\Math\BigInteger

--- a/src/AddressBase.php
+++ b/src/AddressBase.php
@@ -2,7 +2,7 @@
 
 namespace Dxw\CIDR;
 
-class AddressBase
+abstract class AddressBase
 {
     /** @var string */
     private $address;

--- a/src/BlockBase.php
+++ b/src/BlockBase.php
@@ -46,4 +46,9 @@ abstract class BlockBase
 
         return new \phpseclib\Math\BigInteger($s, 2);
     }
+
+    public function __toString(): string
+    {
+        return sprintf('/%d', $this->value);
+    }
 }

--- a/src/BlockBase.php
+++ b/src/BlockBase.php
@@ -2,7 +2,7 @@
 
 namespace Dxw\CIDR;
 
-class BlockBase
+abstract class BlockBase
 {
     /** @var int */
     private $value;

--- a/src/IPv4Address.php
+++ b/src/IPv4Address.php
@@ -4,6 +4,9 @@ namespace Dxw\CIDR;
 
 class IPv4Address extends AddressBase
 {
+    /** @var int */
+    protected static $size = 32;
+
     public static function Make(string $address): \Dxw\Result\Result
     {
         if (strpos($address, '.') === false || strpos($address, ':') !== false) {

--- a/src/IPv4Range.php
+++ b/src/IPv4Range.php
@@ -2,12 +2,16 @@
 
 namespace Dxw\CIDR;
 
-class IPv4Range
+class IPv4Range extends RangeBase
 {
     /** @var IPv4Address */
     private $address;
+
     /** @var IPv4Block */
-    private $block;
+    protected $block;
+
+    /** @var string */
+    protected static $addressClass = IPv4Address::class;
 
     public static function Make(string $range): \Dxw\Result\Result
     {

--- a/src/IPv6Address.php
+++ b/src/IPv6Address.php
@@ -4,6 +4,9 @@ namespace Dxw\CIDR;
 
 class IPv6Address extends AddressBase
 {
+    /** @var int */
+    protected static $size = 128;
+
     public static function Make(string $address): \Dxw\Result\Result
     {
         if (strpos($address, ':') === false) {

--- a/src/IPv6Range.php
+++ b/src/IPv6Range.php
@@ -2,13 +2,16 @@
 
 namespace Dxw\CIDR;
 
-class IPv6Range
+class IPv6Range extends RangeBase
 {
     /** @var IPv6Address */
     private $address;
 
     /** @var IPv6Block */
-    private $block;
+    protected $block;
+
+    /** @var string */
+    protected static $addressClass = IPv6Address::class;
 
     public static function Make(string $range): \Dxw\Result\Result
     {

--- a/src/RangeBase.php
+++ b/src/RangeBase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Dxw\CIDR;
+
+abstract class RangeBase
+{
+    /** @psalm-var class-string */
+    protected static $addressClass;
+
+    /** @var BlockBase */
+    protected $block;
+
+    abstract public function getAddress();
+
+    abstract public function getBlock();
+
+    public function __toString(): string
+    {
+        $address = $this->getAddress()->getBinary();
+        $netmask = $this->getBlock()->getNetmask();
+        $masked = $address->bitwise_and($netmask);
+
+        $result = static::$addressClass::FromBinary($masked);
+        // $result->isErr() should never be true since the address is already
+        // known to be valid
+        if ($result->isErr()) {
+            throw new \ErrorException("unexpected error returned from FromBinary() constructor");
+        }
+
+        return sprintf('%s%s', $result->unwrap(), $this->block);
+    }
+}


### PR DESCRIPTION
There's actually no method to get an IP range in the form `2001:db8::/64` out of the `IPv4Range` or `IPv6Range` classes. This would fix that.

- [x] Add `IPv*Address::FromBinary()` constuctors
- [x] Add `IPv*Block->__toString()` methods
- [x] Add `IPv*Range->__toString()` methods
- [x] Add extra tests for `IPv*Address::FromBinary()`
- [x] Add extra tests for `IPv*Range->__toString()`